### PR TITLE
added `index.d.ts` definition file to support TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ npm install --save cross-fetch
 As a [ponyfill](https://github.com/sindresorhus/ponyfill):
 
 ```javascript
-// Using ES6 modules
+// Using ES6 modules with Babel or TypeScript
 import fetch from 'cross-fetch';
 
 // Using CommonJS modules

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,3 @@
+declare module "cross-fetch" {
+  export default fetch;
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "homepage": "https://github.com/lquixada/cross-fetch",
   "main": "dist/node-ponyfill.js",
   "browser": "dist/browser-ponyfill.js",
+  "typings": "index.d.ts",
   "scripts": {
     "precommit": "lint-staged",
     "build": "rollup -c",
@@ -56,7 +57,8 @@
   },
   "files": [
     "dist",
-    "polyfill"
+    "polyfill",
+    "index.d.ts"
   ],
   "keywords": [
     "fetch",


### PR DESCRIPTION
Hey,

Thanks for the package!

I added a definition file to support TypeScript out of the box. `fetch` is declared in [lib.dom.d.ts](https://github.com/Microsoft/TypeScript/blob/master/lib/lib.dom.d.ts#L15945) internally in TS and this definition file just adds an alias to that.

Note: It will not work for pure node environment if the `dom` is not referenced in the `lib` [tsconfig compiler option](https://www.typescriptlang.org/docs/handbook/compiler-options.html). I think this should not be a problem, as for a pure node project which doesn't use `dom`, `cross-fetch` will not be used as it makes more sense to use a simpler library that is tailed for node only, like `request` or `node-fetch` directly.