### PR TITLE
Relax version constraint for node-fetch and whatwg-fetch to allow patch releases.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "url": "https://github.com/lquixada/cross-fetch/issues"
   },
   "dependencies": {
-    "node-fetch": "2.1.2",
-    "whatwg-fetch": "2.0.4"
+    "node-fetch": "~2.1.2",
+    "whatwg-fetch": "~2.0.4"
   },
   "devDependencies": {
     "chai": "4.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3788,7 +3788,7 @@ nock@9.2.3:
     qs "^6.5.1"
     semver "^5.5.0"
 
-node-fetch@2.1.2:
+node-fetch@~2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
 
@@ -5529,7 +5529,7 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   dependencies:
     iconv-lite "0.4.19"
 
-whatwg-fetch@2.0.4:
+whatwg-fetch@~2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
 


### PR DESCRIPTION
While the dependencies were bumped in e841512c9c64e0bc7e8205b0b989ba44c31b6bbc, that commit still hasn't been released. To allow users in the future access to patch releases without `cross-fetch` having to make a new release, I propose ease the constraint.