### PR TITLE
Fix breaking global fetch in react native

### DIFF
--- a/dist/browser-ponyfill.js
+++ b/dist/browser-ponyfill.js
@@ -1,3 +1,4 @@
+var realFetch = this && this.fetch;
 var __root__ = (function (root) {
 function F() { this.fetch = false; }
 F.prototype = root;


### PR DESCRIPTION
Importing the ponyfill version of this library in react native breaks the
globally defined fetch. This was reported to our library in
https://github.com/GetStream/react-native-activity-feed/issues/24 and
https://github.com/GetStream/react-native-activity-feed/issues/23.

The suggested change fixes this problem. I'm surprised it worked myself and I'm
not completely sure why. It seems fetch is loaded lazily in react native and
the way that it is read by the current implementation doesn't trigger this
loading.