### PR TITLE
react-native doesn't require a ponyfill as it already polyfills fetch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ sauce:
 snyk:
 	npx snyk test
 
-test: test-node test-node-webpack test-browser test-browser-webpack lint
+test: test-node test-node-webpack test-browser test-browser-webpack test-react-native lint
 
 test-browser: build
 	npx mocha-headless-chrome -f test/browser/headless/index.html
@@ -43,5 +43,8 @@ test-node: build
 
 test-node-webpack: build build-node-webpack
 	npx mocha test/node/webpack/bundle.*.js
+
+test-react-native: build
+	npx mocha test/react-native/index.js
 
 .PHONY: all build build-browser-webpack build-node-webpack deploy lint test test-browser test-browser-webpack test-node test-node-webpack  sauce

--- a/dist/react-native-polyfill.js
+++ b/dist/react-native-polyfill.js
@@ -1,0 +1,1 @@
+// React native already polyfills `fetch` so there is intentionally no work being done here.

--- a/dist/react-native-ponyfill.js
+++ b/dist/react-native-ponyfill.js
@@ -1,0 +1,8 @@
+module.exports = exports = global.fetch
+exports.fetch = global.fetch
+exports.Headers = global.Headers
+exports.Request = global.Request
+exports.Response = global.Response
+
+// Needed for TypeScript consumers without esModuleInterop.
+exports.default = global.fetch

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "homepage": "https://github.com/lquixada/cross-fetch",
   "main": "dist/node-ponyfill.js",
   "browser": "dist/browser-ponyfill.js",
+  "react-native": "dist/react-native-ponyfill.js",
   "typings": "index.d.ts",
   "lint-staged": {
     "*.js": [

--- a/polyfill/package.json
+++ b/polyfill/package.json
@@ -2,5 +2,6 @@
   "name": "cross-fetch-polyfill",
   "version": "0.0.0",
   "main": "../dist/node-polyfill.js",
-  "browser": "../dist/browser-polyfill.js"
+  "browser": "../dist/browser-polyfill.js",
+  "react-native": "../dist/react-native-polyfill.js"
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -69,6 +69,7 @@ export default [
     plugins: [
       copy({
         'src/node-polyfill.js': 'dist/node-polyfill.js',
+        'src/react-native-ponyfill.js': 'dist/react-native-ponyfill.js',
         verbose: true
       })
     ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -45,6 +45,7 @@ export default [
     plugins: [
       copy({
         'src/node-ponyfill.js': 'dist/node-ponyfill.js',
+        'src/react-native-ponyfill.js': 'dist/react-native-ponyfill.js',
         verbose: true
       })
     ],
@@ -69,7 +70,7 @@ export default [
     plugins: [
       copy({
         'src/node-polyfill.js': 'dist/node-polyfill.js',
-        'src/react-native-ponyfill.js': 'dist/react-native-ponyfill.js',
+        'src/react-native-polyfill.js': 'dist/react-native-polyfill.js',
         verbose: true
       })
     ],

--- a/src/react-native-polyfill.js
+++ b/src/react-native-polyfill.js
@@ -1,0 +1,1 @@
+// React native already polyfills `fetch` so there is intentionally no work being done here.

--- a/src/react-native-ponyfill.js
+++ b/src/react-native-ponyfill.js
@@ -1,0 +1,8 @@
+module.exports = exports = global.fetch
+exports.fetch = global.fetch
+exports.Headers = global.Headers
+exports.Request = global.Request
+exports.Response = global.Response
+
+// Needed for TypeScript consumers without esModuleInterop.
+exports.default = global.fetch

--- a/test/react-native/index.js
+++ b/test/react-native/index.js
@@ -17,4 +17,23 @@ describe('react-native', function () {
     delete global.Request
     delete global.Response
   })
+
+  it('doesn\'t touch the global functions when polyfilling', function () {
+    const globalFetch = global.fetch = function globalFetch () {}
+    const globalHeaders = global.Headers = function globalHeaders () {}
+    const globalRequest = global.Request = function globalRequest () {}
+    const globalResponse = global.Response = function globalResponse () {}
+
+    require('../../dist/react-native-polyfill')
+
+    expect(fetch).to.equal(globalFetch)
+    expect(Headers).to.equal(globalHeaders)
+    expect(Request).to.equal(globalRequest)
+    expect(Response).to.equal(globalResponse)
+
+    delete global.fetch
+    delete global.Headers
+    delete global.Request
+    delete global.Response
+  })
 })

--- a/test/react-native/index.js
+++ b/test/react-native/index.js
@@ -1,0 +1,20 @@
+describe('react-native', function () {
+  it('just re-exports the global functions', function () {
+    const globalFetch = global.fetch = function globalFetch () {}
+    const globalHeaders = global.Headers = function globalHeaders () {}
+    const globalRequest = global.Request = function globalRequest () {}
+    const globalResponse = global.Response = function globalResponse () {}
+
+    const { fetch, Request, Response, Headers } = require('../../dist/react-native-ponyfill')
+
+    expect(fetch).to.equal(globalFetch)
+    expect(Headers).to.equal(globalHeaders)
+    expect(Request).to.equal(globalRequest)
+    expect(Response).to.equal(globalResponse)
+
+    delete global.fetch
+    delete global.Headers
+    delete global.Request
+    delete global.Response
+  })
+})


### PR DESCRIPTION
This is an attempt to fix this [issue](https://github.com/lquixada/cross-fetch/issues/38) such that:
1. The bundle size can be smaller as it won't need to include another implementation of `fetch`
1. Timing/global state issues are addressed and `global.fetch` isn't set to `false`