### PR TITLE
upgrade node-fetch to 2.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4711,9 +4711,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
-      "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.5.0.tgz",
+      "integrity": "sha512-YuZKluhWGJwCcUu4RlZstdAxr8bFfOVHakc1mplwHkk8J+tqM1Y5yraYvIUpeX8aY7+crCwiELJq7Vl0o0LWXw=="
     },
     "node-libs-browser": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "url": "https://github.com/lquixada/cross-fetch/issues"
   },
   "dependencies": {
-    "node-fetch": "2.3.0",
+    "node-fetch": "2.5.0",
     "whatwg-fetch": "3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Node-fetch 2.5.0 now allows for third-party blob implementation. This allows user to manually create Blob for their fetch requests (for multipart request for example)