### PR TITLE
added native ESM version for node.

### DIFF
--- a/dist/node-ponyfill.mjs
+++ b/dist/node-ponyfill.mjs
@@ -1,0 +1,18 @@
+import nodeFetch from 'node-fetch'
+var realFetch = nodeFetch.default || nodeFetch
+
+var fetch = function (url, options) {
+  // Support schemaless URIs on the server for parity with the browser.
+  // Ex: //github.com/ -> https://github.com/
+  if (/^\/\//.test(url)) {
+    url = 'https:' + url
+  }
+  return realFetch.call(this, url, options)
+}
+
+export default fetch
+
+export { fetch }
+export const Headers = nodeFetch.Headers
+export const Request = nodeFetch.Request
+export const Response = nodeFetch.Response

--- a/package.json
+++ b/package.json
@@ -5,6 +5,17 @@
   "homepage": "https://github.com/lquixada/cross-fetch",
   "main": "dist/node-ponyfill.js",
   "browser": "dist/browser-ponyfill.js",
+  "exports": {
+    ".": {
+      "require": "./dist/node-ponyfill.js",
+      "import": "./dist/node-ponyfill.mjs"
+    },
+    "./polyfill": {
+      "require": "./dist/node-polyfill.js",
+      "import": "./dist/node-polyfill.js"
+    }
+  },
+  "sideEffects": ["./dist/node-polyfill.js"],
   "react-native": "dist/react-native-ponyfill.js",
   "typings": "index.d.ts",
   "lint-staged": {

--- a/src/node-ponyfill.mjs
+++ b/src/node-ponyfill.mjs
@@ -1,0 +1,18 @@
+import nodeFetch from 'node-fetch'
+var realFetch = nodeFetch.default || nodeFetch
+
+var fetch = function (url, options) {
+  // Support schemaless URIs on the server for parity with the browser.
+  // Ex: //github.com/ -> https://github.com/
+  if (/^\/\//.test(url)) {
+    url = 'https:' + url
+  }
+  return realFetch.call(this, url, options)
+}
+
+export default fetch
+
+export { fetch }
+export const Headers = nodeFetch.Headers
+export const Request = nodeFetch.Request
+export const Response = nodeFetch.Response


### PR DESCRIPTION
Currently, using this package with native ESM loading fails with an error like this:
```
import { fetch, Headers } from 'cross-fetch';
         ^^^^^
SyntaxError: The requested module 'cross-fetch' does not provide an export named 'fetch'
```
This pull request fixes that by adding a separate ESM version of the ponyfill and referencing it in the `exports` key of package.json.
The polyfill doesn't need a special version (since it doesn't export anything) but still needs to be referenced in the `exports`.