### PR TITLE
moved whatwg-fetch into devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,7 @@
     "url": "https://github.com/lquixada/cross-fetch/issues"
   },
   "dependencies": {
-    "node-fetch": "2.6.0",
-    "whatwg-fetch": "3.0.0"
+    "node-fetch": "2.6.0"
   },
   "devDependencies": {
     "chai": "4.2.0",
@@ -67,7 +66,8 @@
     "sinon": "9.0.0",
     "standard": "14.3.1",
     "webpack": "4.42.0",
-    "webpack-cli": "3.3.11"
+    "webpack-cli": "3.3.11",
+    "whatwg-fetch": "3.0.0"
   },
   "files": [
     "dist",


### PR DESCRIPTION
Seems it's bundled when building an not needed as dependency.