### PR TITLE
Ponyfill `readAsArrayBuffer` for react-native

### DIFF
--- a/dist/react-native-ponyfill.js
+++ b/dist/react-native-ponyfill.js
@@ -4,3 +4,39 @@ module.exports.fetch = global.fetch // To enable: import {fetch} from 'cross-fet
 module.exports.Headers = global.Headers
 module.exports.Request = global.Request
 module.exports.Response = global.Response
+
+// from: https://github.com/facebook/react-native/issues/21209#issuecomment-495294672
+
+FileReader.prototype.readAsArrayBuffer = function (blob) {
+  if (this.readyState === this.LOADING) throw new Error('InvalidStateError')
+  this._setReadyState(this.LOADING)
+  this._result = null
+  this._error = null
+  const fr = new FileReader()
+  fr.onloadend = () => {
+    const content = atob(fr.result.substr('data:application/octet-stream;base64,'.length))
+    const buffer = new ArrayBuffer(content.length)
+    const view = new Uint8Array(buffer)
+    view.set(Array.from(content).map(c => c.charCodeAt(0)))
+    this._result = buffer
+    this._setReadyState(this.DONE)
+  }
+  fr.readAsDataURL(blob)
+}
+
+// from: https://stackoverflow.com/questions/42829838/react-native-atob-btoa-not-working-without-remote-js-debugging
+const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/='
+const atob = (input = '') => {
+  const str = input.replace(/=+$/, '')
+  let output = ''
+
+  if (str.length % 4 === 1) {
+    throw new Error("'atob' failed: The string to be decoded is not correctly encoded.")
+  }
+  for (let bc = 0, bs = 0, buffer, i = 0; (buffer = str.charAt(i++)); ~buffer && (bs = bc % 4 ? bs * 64 + buffer : buffer, bc++ % 4) ? output += String.fromCharCode(255 & bs >> (-2 * bc & 6)) : 0
+  ) {
+    buffer = chars.indexOf(buffer)
+  }
+
+  return output
+}

--- a/dist/react-native-ponyfill.js
+++ b/dist/react-native-ponyfill.js
@@ -17,7 +17,9 @@ FileReader.prototype.readAsArrayBuffer = function (blob) {
     const content = atob(fr.result.substr('data:application/octet-stream;base64,'.length))
     const buffer = new ArrayBuffer(content.length)
     const view = new Uint8Array(buffer)
-    view.set(Array.from(content).map(c => c.charCodeAt(0)))
+    for (let i = 0; i < content.length; i++) {
+      view.fill(content[i].charCodeAt(0), i, i + 1)
+    }
     this._result = buffer
     this._setReadyState(this.DONE)
   }
@@ -37,6 +39,5 @@ const atob = (input = '') => {
   ) {
     buffer = chars.indexOf(buffer)
   }
-
   return output
 }

--- a/src/react-native-ponyfill.js
+++ b/src/react-native-ponyfill.js
@@ -4,3 +4,38 @@ module.exports.fetch = global.fetch // To enable: import {fetch} from 'cross-fet
 module.exports.Headers = global.Headers
 module.exports.Request = global.Request
 module.exports.Response = global.Response
+
+// from: https://github.com/facebook/react-native/issues/21209#issuecomment-495294672
+
+FileReader.prototype.readAsArrayBuffer = function (blob) {
+  if (this.readyState === this.LOADING) throw new Error('InvalidStateError')
+  this._setReadyState(this.LOADING)
+  this._result = null
+  this._error = null
+  const fr = new FileReader()
+  fr.onloadend = () => {
+    const content = atob(fr.result.substr('data:application/octet-stream;base64,'.length))
+    const buffer = new ArrayBuffer(content.length)
+    const view = new Uint8Array(buffer)
+    view.set(Array.from(content).map(c => c.charCodeAt(0)))
+    this._result = buffer
+    this._setReadyState(this.DONE)
+  }
+  fr.readAsDataURL(blob)
+}
+
+// from: https://stackoverflow.com/questions/42829838/react-native-atob-btoa-not-working-without-remote-js-debugging
+const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/='
+const atob = (input = '') => {
+  const str = input.replace(/=+$/, '')
+  let output = ''
+
+  if (str.length % 4 === 1) {
+    throw new Error("'atob' failed: The string to be decoded is not correctly encoded.")
+  }
+  for (let bc = 0, bs = 0, buffer, i = 0; (buffer = str.charAt(i++)); ~buffer && (bs = bc % 4 ? bs * 64 + buffer : buffer, bc++ % 4) ? output += String.fromCharCode(255 & bs >> (-2 * bc & 6)) : 0
+  ) {
+    buffer = chars.indexOf(buffer)
+  }
+  return output
+}

--- a/src/react-native-ponyfill.js
+++ b/src/react-native-ponyfill.js
@@ -17,7 +17,9 @@ FileReader.prototype.readAsArrayBuffer = function (blob) {
     const content = atob(fr.result.substr('data:application/octet-stream;base64,'.length))
     const buffer = new ArrayBuffer(content.length)
     const view = new Uint8Array(buffer)
-    view.set(Array.from(content).map(c => c.charCodeAt(0)))
+    for (let i = 0; i < content.length; i++) {
+      view.fill(content[i].charCodeAt(0), i, i + 1)
+    }
     this._result = buffer
     this._setReadyState(this.DONE)
   }


### PR DESCRIPTION
It's been a long-standing problem that [react-native fetch does not implement `readAsArrayBuffer`](https://github.com/facebook/react-native/blob/master/Libraries/Blob/FileReader.js#L83) (which will cause `fetch(...).then(r => r.arrayBuffer())` to throw an exception).

I found a workaround [here](https://github.com/facebook/react-native/issues/21209#issuecomment-495294672), and I hope including this into `cross-fetch` will be beneficial.

---

BTW, forking and customizing this repository is basically for the convenience of my own project, and I understand that `cross-fetch` should only serve as a proxy for the existing libraries and should not add new features. So I will leave this pr as a draft and it is open to adjustments or rejection.