### PR TITLE
Fix iteration methods are missing in Headers type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
 /// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
 
 declare const _fetch: typeof fetch;
 declare const _Request: typeof Request;


### PR DESCRIPTION
This pull request adds reference to `dom.iterable` lib in `index.d.ts`, because some methods to iterate over `Headers` are declared in `lib.dom.iterable.d.ts` instead of `lib.dom.d.ts`.

https://github.com/microsoft/TypeScript/blob/v4.4.3/lib/lib.dom.d.ts#L8910-L8918
https://github.com/microsoft/TypeScript/blob/v4.4.3/lib/lib.dom.iterable.d.ts#L115-L129

With this change we can call [`Headers.entries()`](https://developer.mozilla.org/en-US/docs/Web/API/Headers/entries), [`Headers.keys()`](https://developer.mozilla.org/en-US/docs/Web/API/Headers/keys), and [`Headers.values()`](https://developer.mozilla.org/en-US/docs/Web/API/Headers/values) method in TypeScript.

```ts
import { Headers } from 'cross-fetch'

const headers = new Headers()
for (const [key, value] of headers.entries()) {
  // ...
}
```