### PR TITLE
chore: updated node-fetch version to 2.6.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x]
+        node-version: [10.x, 12.x, 14.x, 16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     steps:
     - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "url": "https://github.com/lquixada/cross-fetch/issues"
   },
   "dependencies": {
-    "node-fetch": "2.6.5"
+    "node-fetch": "2.6.7"
   },
   "devDependencies": {
     "@commitlint/cli": "12.0.1",


### PR DESCRIPTION
Fixes  [CVE-2022-0235](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-0235)

Fixes #123 

node-fetch 2.6.7 [release notes](https://github.com/node-fetch/node-fetch/releases/tag/v2.6.7)