### PR TITLE
Update away from vulnerable version of node-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "url": "https://github.com/lquixada/cross-fetch/issues"
   },
   "dependencies": {
-    "node-fetch": "^2.6.1",
+    "node-fetch": "^2.6.7",
     "whatwg-fetch": "2.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Backporting #124 to the 2.x branch for dependencies stuck on that which can't get a PR for moving on reviewed, e.g. https://github.com/MetaMask/web3-provider-engine/pull/404