### PR TITLE
fix: use existing fetch if it exists, otherwise fallback to whatwg-fetch

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -46,8 +46,7 @@ export default [
         delete __self__.fetch.polyfill;
 
         // Choose between native implementation (global) or custom implementation (__self__)
-        // var ctx = global.fetch ? global : __self__;
-        var ctx = __self__; // this line disable service worker support temporarily
+        var ctx = global.fetch ? global : __self__;
 
         exports = ctx.fetch // To enable: import fetch from 'cross-fetch'
         exports.default = ctx.fetch // For TypeScript consumers without esModuleInterop.


### PR DESCRIPTION
I'm not sure why the code was written the way it is, but it appears to be forcing the polyfill to be used even in environments where the Fetch API exists natively, which isn't intentional and causes the bugs described in #91, #78, and #69.

The original commit and PR don't describe why the behaviour was changed: https://github.com/lquixada/cross-fetch/commit/123b1a2ef13f279f444118398959fb3424abfca4