### PR TITLE
chore: updated  node-fetch version to 3.2.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "url": "https://github.com/lquixada/cross-fetch/issues"
   },
   "dependencies": {
-    "node-fetch": "^2.6.7"
+    "node-fetch": "^3.2.10"
   },
   "devDependencies": {
     "@commitlint/cli": "12.0.1",


### PR DESCRIPTION
There is some vulnerabilities found in the  node-fetch package 
https://github.com/node-fetch/node-fetch/commit/28802387292baee467e042e168d92597b5bbbe3d
https://cwe.mitre.org/data/definitions/400