### PR TITLE
fix: add types to polyfill

### DIFF
--- a/polyfill/package.json
+++ b/polyfill/package.json
@@ -4,5 +4,6 @@
   "main": "../dist/node-polyfill.js",
   "browser": "../dist/browser-polyfill.js",
   "react-native": "../dist/react-native-polyfill.js",
+  "types": "../index.d.ts",
   "license": "MIT"
 }


### PR DESCRIPTION
Type definition resolution isn't working for me when importing cross-fetch/polyfill. Adding the `types` property to the package.json file resolves this issue.

```ts
import 'cross-fetch/polyfill'
//  error TS2304: Cannot find name 'Request'.
```