### PR TITLE
fix: avoid polluting global namespace in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,14 +1,9 @@
 /// <reference lib="dom" />
 
-declare const _fetch: typeof fetch;
-declare const _Request: typeof Request;
-declare const _Response: typeof Response;
-declare const _Headers: typeof Headers;
-
 declare module "cross-fetch" {
-  export const fetch: typeof _fetch;
-  export const Request: typeof _Request;
-  export const Response: typeof _Response;
-  export const Headers: typeof _Headers;
+  export const fetch: typeof global.fetch;
+  export const Request: typeof global.Request;
+  export const Response: typeof global.Response;
+  export const Headers: typeof global.Headers;
   export default fetch;
 }


### PR DESCRIPTION
The top-level declarations of `_fetch` etc. pollute the global namespace, potentially causing conflicts with other libraries. This switches the type declarations to access the desired values through the `global` object instead.

As far as I can tell this should not cause any issues, although I'm lacking context on why the types are declared the way they are to begin with.