### PR TITLE
Fix: Update node-fetch to 2.6.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "url": "https://github.com/lquixada/cross-fetch/issues"
   },
   "dependencies": {
-    "node-fetch": "^2.6.12"
+    "node-fetch": "^2.6.13"
   },
   "devDependencies": {
     "@commitlint/cli": "12.0.1",


### PR DESCRIPTION
This PR updates Node Fetch to 2.6.13, to fix https://github.com/node-fetch/node-fetch/issues/1735 and https://github.com/node-fetch/node-fetch/pull/1765