### PR TITLE
chore: updated node-fetch to 2.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "url": "https://github.com/lquixada/cross-fetch/issues"
   },
   "dependencies": {
-    "node-fetch": "^2.6.12"
+    "node-fetch": "^2.7.0"
   },
   "devDependencies": {
     "@commitlint/cli": "17.6.6",


### PR DESCRIPTION
Updates node-fetch to 2.7.0 and potentially addresses concerns on #183 .