### PR TITLE
chore: switched minifier from @rollup/plugin-terser to rollup-plugin-esbuild

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,8 +28,6 @@ jobs:
     name: Install
     runs-on: ubuntu-latest
     steps:
-    - name: Blah
-      run: echo blah
     - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,6 +28,8 @@ jobs:
     name: Install
     runs-on: ubuntu-latest
     steps:
+    - name: Blah
+      run: echo blah
     - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "rimraf": "5.0.1",
     "rollup": "3.26.0",
     "rollup-plugin-copy": "3.4.0",
+    "rollup-plugin-esbuild": "6.1.1",
     "rollup-plugin-esbuild-minify": "1.1.2",
     "semver": "7.5.3",
     "serve-index": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
   "devDependencies": {
     "@commitlint/cli": "17.6.6",
     "@commitlint/config-conventional": "17.6.6",
-    "@rollup/plugin-terser": "0.4.3",
     "@types/chai": "4.3.5",
     "@types/mocha": "10.0.1",
     "@types/node": "18.15.13",
@@ -92,6 +91,7 @@
     "rimraf": "5.0.1",
     "rollup": "3.26.0",
     "rollup-plugin-copy": "3.4.0",
+    "rollup-plugin-esbuild-minify": "1.1.2",
     "semver": "7.5.3",
     "serve-index": "1.9.1",
     "standard": "17.1.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,7 @@
 /* Rollup creates the browser version of the polyfill and ponyfill. */
 import path from 'path'
 import copy from 'rollup-plugin-copy'
-import { minify } from 'rollup-plugin-esbuild-minify'
+import { minify } from 'rollup-plugin-esbuild'
 
 const input = path.join(__dirname, 'node_modules', 'whatwg-fetch', 'fetch.js')
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,7 @@
 /* Rollup creates the browser version of the polyfill and ponyfill. */
 import path from 'path'
 import copy from 'rollup-plugin-copy'
-import terser from '@rollup/plugin-terser'
+import { minify } from 'rollup-plugin-esbuild-minify'
 
 const input = path.join(__dirname, 'node_modules', 'whatwg-fetch', 'fetch.js')
 
@@ -128,7 +128,7 @@ export default [
       `)
     },
     plugins: [
-      terser()
+      minify()
     ]
   }
 ]


### PR DESCRIPTION
`@rollup/plugin-terser` has a dependency called `smob`, whose lastest release (v1.5.0 at the time of this PR) breaks compatibility with Node 16.5-. `cross-fetch@4.*` minimum support for Node is 14. [More on the issue here](https://github.com/tada5hi/smob/issues/402).

This PR replaces `@roll-up/plugin-terser` with `rollup-plugin-esbuild` for minification.