### PR TITLE
chore: removed cache usage from release workflow to prevent Supply Chain attack

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -44,10 +44,6 @@ jobs:
       with:
         path: ~/.npm # this is cache where npm installs from before going out to the network
         key: ${{ runner.os }}-node-${{ hashFiles('**/package.json') }}
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ matrix.node-version }}
     - run: npm install --prefer-offline
     - run: make test-browser
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,5 @@
+# Note: The cache steps on this workflow has been removed Supply Chain attack through Github Action Pwn Request.
+# Here's more info on how that works: https://adnanthekhan.com/2024/05/06/the-monsters-in-your-build-cache-github-actions-cache-poisoning/
 name: v4.x releases
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,10 +42,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ matrix.node-version }}
     - run: npm install --prefer-offline
     - run: make test-browser
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,46 +12,64 @@ on:
     - 'v4.[0-9]+.[0-9]+-beta.[0-9]+'
 
 jobs:
-  install:
-    name: Install
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - name: Cache node_modules
-      id: cacheModules
-      uses: actions/cache@v4
-      with:
-        path: ~/.npm # cache where "npm install" uses before going out to the network
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package.json') }}
-    - name: Install dependencies
-      if: steps.cacheModules.outputs.cache-hit != 'true'
-      run: npm install
-
   debug:
     name: Debug
     runs-on: ubuntu-latest
     steps:
     - uses: hmarr/debug-action@v3
 
-  checks:
-    name: Check
-    needs: [install]
-    uses: ./.github/workflows/checks.yml
-    with:
-      ref: ${{ github.sha }}
+  test-node:
+    name: Node Test Specs
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [14.x, 16.x, 18.x, 20.x, 22.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install --prefer-offline
+    - run: make test-node
+
+  test-browser:
+    name: Browser Test Specs
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install --prefer-offline
+    - run: make test-browser
+
+  lint:
+    name: Code Lint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - run: npm install --prefer-offline
+    - run: make lint
+
+  typecheck:
+    name: Types
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - run: npm install --prefer-offline
+    - run: make typecheck
 
   # The security job can't run on pull requests opened from forks because
   # Github doesn't pass down the SNYK_TOKEN environment variable.
   security:
     name: Check Security
-    needs: [install]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/cache@v4
-      with:
-        path: ~/.npm # cache where "npm install" uses before going out to the network
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package.json') }}
     - run: npm install --prefer-offline
     - run: make secure
       env:
@@ -60,7 +78,7 @@ jobs:
   publish:
     name: Publish to NPM registry
     runs-on: ubuntu-latest
-    needs: [checks, security]
+    needs: [test-node, test-browser, lint, typecheck, security]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
@@ -68,10 +86,6 @@ jobs:
         node-version-file: '.nvmrc'
         # Setup .npmrc file to publish to npm
         registry-url: 'https://registry.npmjs.org'
-    - uses: actions/cache@v4
-      with:
-        path: ~/.npm # this is cache where npm installs from before going out to the network
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package.json') }}
     - run: npm install --prefer-offline
     - run: make publish
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-# Note: The cache steps on this workflow has been removed Supply Chain attack through Github Action Pwn Request.
+# Note: The cache steps on this workflow has been removed Supply Chain attack through GitHub Action Pwn Request.
 # Here's more info on how that works: https://adnanthekhan.com/2024/05/06/the-monsters-in-your-build-cache-github-actions-cache-poisoning/
 name: v4.x releases
 


### PR DESCRIPTION
This PR addresses a security issue called GitHub Action Pwn Request in the release workflow. It removes all cache steps to prevent cache poisoning from malicious pull requests. [Here's more info on how that works](https://adnanthekhan.com/2024/05/06/the-monsters-in-your-build-cache-github-actions-cache-poisoning/).
This was pointed out in a report provided by Roni Carta and Adnan Khan. Kudos to them!
