### PR TITLE
chore: added no-sandbox arg to fix browser test

### DIFF
--- a/test/fetch-api/browser/run.sh
+++ b/test/fetch-api/browser/run.sh
@@ -2,4 +2,4 @@
 
 . test/setup/server.sh
 
-npx mocha-headless-chrome -f http://127.0.0.1:8000/$(dirname $0)/index.html?globals=on
+npx mocha-headless-chrome -f http://127.0.0.1:8000/$(dirname $0)/index.html?globals=on -a no-sandbox -a disable-setuid-sandbox

--- a/test/fetch-api/service-worker/run.sh
+++ b/test/fetch-api/service-worker/run.sh
@@ -3,4 +3,5 @@
 . test/setup/server.sh
 
 npx webpack --config $(dirname "$0")/webpack.config.js &&
-npx mocha-headless-chrome -f http://127.0.0.1:8000/$(dirname $0)/index.html
+npx mocha-headless-chrome -f http://127.0.0.1:8000/$(dirname $0)/index.html -a no-sandbox -a disable-setuid-sandbox
+

--- a/test/fetch-api/whatwg/run.sh
+++ b/test/fetch-api/whatwg/run.sh
@@ -2,4 +2,5 @@
 
 . test/setup/server.sh
 
-npx mocha-headless-chrome -f http://127.0.0.1:8000/$(dirname $0)/index.html?globals=off
+npx mocha-headless-chrome -f http://127.0.0.1:8000/$(dirname $0)/index.html?globals=off -a no-sandbox -a disable-setuid-sandbox
+

--- a/test/module-system/web.cjs/run.sh
+++ b/test/module-system/web.cjs/run.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 npx webpack --config $(dirname "$0")/webpack.config.js &&
-npx mocha-headless-chrome -f $(dirname "$0")/polyfill.html?globals=off &&
-npx mocha-headless-chrome -f $(dirname "$0")/polyfill.html?globals=on &&
-npx mocha-headless-chrome -f $(dirname "$0")/ponyfill.html?globals=off &&
-npx mocha-headless-chrome -f $(dirname "$0")/ponyfill.html?globals=on
+npx mocha-headless-chrome -f $(dirname "$0")/polyfill.html?globals=off -a no-sandbox -a disable-setuid-sandbox &&
+npx mocha-headless-chrome -f $(dirname "$0")/polyfill.html?globals=on -a no-sandbox -a disable-setuid-sandbox &&
+npx mocha-headless-chrome -f $(dirname "$0")/ponyfill.html?globals=off -a no-sandbox -a disable-setuid-sandbox &&
+npx mocha-headless-chrome -f $(dirname "$0")/ponyfill.html?globals=on -a no-sandbox -a disable-setuid-sandbox

--- a/test/module-system/web.esm/run.sh
+++ b/test/module-system/web.esm/run.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 npx webpack --config $(dirname "$0")/webpack.config.js &&
-npx mocha-headless-chrome -f $(dirname "$0")/polyfill.html?globals=off &&
-npx mocha-headless-chrome -f $(dirname "$0")/polyfill.html?globals=on &&
-npx mocha-headless-chrome -f $(dirname "$0")/ponyfill.html?globals=off &&
-npx mocha-headless-chrome -f $(dirname "$0")/ponyfill.html?globals=on
+npx mocha-headless-chrome -f $(dirname "$0")/polyfill.html?globals=off -a no-sandbox -a disable-setuid-sandbox &&
+npx mocha-headless-chrome -f $(dirname "$0")/polyfill.html?globals=on -a no-sandbox -a disable-setuid-sandbox &&
+npx mocha-headless-chrome -f $(dirname "$0")/ponyfill.html?globals=off -a no-sandbox -a disable-setuid-sandbox &&
+npx mocha-headless-chrome -f $(dirname "$0")/ponyfill.html?globals=on -a no-sandbox -a disable-setuid-sandbox
+


### PR DESCRIPTION
This PR fixes the following error when running `mocha-headless-chrome` on browser tests.

```
Error: Failed to launch the browser process!
[0412/132242.907137:FATAL:zygote_host_impl_linux.cc(117)] No usable sandbox! Update your kernel or see https://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md for more information on developing with the SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.
#0 0x555f91c40b89 base::debug::CollectStackTrace()
#1 0x555f91ba5433 base::debug::StackTrace::StackTrace()
#2 0x555f91bb8330 logging::LogMessage::~LogMessage()
#3 0x555f8fb9d99b content::ZygoteHostImpl::Init()
#4 0x555f9174e372 content::ContentMainRunnerImpl::Initialize()
#5 0x555f9174c439 content::RunContentProcess()
#6 0x555f9174c58e content::ContentMain()
#7 0x555f917a7d7a headless::(anonymous namespace)::RunContentMain()
#8 0x555f917a7a85 headless::HeadlessShellMain()
#9 0x555f8e20b3e8 ChromeMain
#10 0x7f8ddac2a1ca (/usr/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9)
#11 0x7f8ddac2a28b __libc_start_main
#12 0x555f8e20b22a _start
```